### PR TITLE
feat: Add non-root user to Dockerfile for security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,14 @@ RUN --mount=type=cache,target=/root/.npm-production npm ci --ignore-scripts --om
 
 RUN --mount=type=cache,target=/root/.npm npm run build
 
+# --- Release Stage ---
 FROM node:22-alpine AS release
 
+# Set up a non-root user ('appuser'/'appgroup') to avoid running as root - good security practice!
+# (-S is the Alpine option for a system user/group, suitable here)
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+# Copy the built code and necessary package files from our builder stage
 COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/package.json /app/package.json
 COPY --from=builder /app/package-lock.json /app/package-lock.json
@@ -18,6 +24,15 @@ ENV NODE_ENV=production
 
 WORKDIR /app
 
+# Give our new 'appuser' ownership of the application files inside /app
+# Needs to happen after copying the files over
+RUN chown -R appuser:appgroup /app
+
+# Install *only* the production dependencies
 RUN npm ci --ignore-scripts --omit-dev
 
+# Now, switch to running as our non-root user for the actual app process
+USER appuser
+
+# Define how to start the application
 ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
Configure Docker image to run as 'appuser' instead of root.

## Description

This PR addresses a critical security concern by configuring the Docker container to run the application as a dedicated, unprivileged non-root user ('appuser') instead of the default 'root' user.

Running containers as root is against security best practices as it increases the potential impact if the application process is compromised. Switching to a non-root user limits the process's privileges within the container.

This change aligns with Docker security recommendations and hardens the deployment environment.

## Changes Made

- Added instructions in the `release` stage of the `Dockerfile` to:
    - Create a new group (`appgroup`) and user (`appuser`).
    - Change ownership of the `/app` directory to `appuser:appgroup`.
- Added the `USER appuser` instruction before the `ENTRYPOINT` to switch to the non-root user.

## Related Issues/PRs

- Complements the work in potential open PR #18 (Add CI that tests docker build and run) by ensuring the tested Docker image follows security best practices.

## Checklist

- [x] Dockerfile updated to use a non-root user
- [ ] Docker image built and tested locally (`docker build .`)